### PR TITLE
feat: allow use of context managers in `tidi.Provider`

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,7 +7,7 @@ The top level import of `tidi` provides everything needed it's [primary intended
 * `tidi.inject` - a decorator that will replace certain keyword arguments with dependencies, based on their type & if they haven't been passed in
 * `tidi.Injected ` - a type alias, wrapping `typing.Annotated`, that indicates that a keyword argument should be injected
 * `tidi.register ` - a function that registers an object to be available for injection as a dependency
-* `tidi.Provider ` - a wrapper class around a function that will be called to provide a dependency
+* `tidi.Provider` - a wrapper class around a function or context manager that will be called to provide a dependency
 * `tidi.UNSET ` - a sentinel object to indicate that a dependency should be loaded from the registry
 * `tidi.field_factory` - a helper function for injecting dependencies into dataclass fields
 
@@ -43,9 +43,10 @@ See the [`tidi.registry`](./registry.md) documentation for more detail.
 
 ### `tidi.Provider`
 
-For more control over what instance is injected, use the provider function.
+For more control over what instance is injected, give a provider of the
+dependency as a function, or as a context manager.
 
-The elected provider function will be called each time the function is called.
+The given provider will be called each time the function is called.
 
 ``` py
 @tidi.inject

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,30 @@ if __name__ == "__main__":
     run()  # 🪄 result from `get_secret()` injected into `run` ✨
 ```
 
+### Inject a dependency provided by a context manager
+
+``` py
+import contextlib
+import typing as t
+
+import tidi
+
+@contextlib.contextmanager
+def open_sesame() -> t.Iterator[str]:
+    logger.info("abracadabra")
+    try:
+        yield "please"
+    finally:
+        logger.info("alakazam")
+
+@tidi.inject
+def run(magic_word: tidi.Injected[str] = tidi.Provider(open_sesame)):
+    logger.info(f"the magic word is {magic_word}")
+
+if __name__ == "__main__":
+    run()  # 🪄 result from `open_sesame()` injected into `run` ✨
+```
+
 ### Or provided by instantiating a class
 
 ``` py

--- a/src/tidi/__init__.py
+++ b/src/tidi/__init__.py
@@ -24,9 +24,13 @@ inject = decorator.inject(registry=default_tidi_registry)
 def field_factory(
     type_: t.Type[T], provider: t.Callable[..., T] | None = None
 ) -> t.Callable[..., T]:
-    return lambda: resolver.resolve_dependency(
-        type_=type_,
-        resolver_options=DEFAULT_RESOLVER_OPTIONS,
-        registry=default_tidi_registry,
-        provider=provider,
-    )
+    def inner():
+        with resolver.resolve_dependency(
+            type_=type_,
+            resolver_options=DEFAULT_RESOLVER_OPTIONS,
+            registry=default_tidi_registry,
+            provider=provider,
+        ) as obj:
+            return obj
+
+    return inner

--- a/src/tidi/resolver.py
+++ b/src/tidi/resolver.py
@@ -1,5 +1,6 @@
 """Finds or creates dependency instances based on availability and options."""
 
+import contextlib
 import typing as t
 from dataclasses import dataclass
 
@@ -29,12 +30,15 @@ class ResolverOptions:
     initialise_missing: bool
 
 
+@contextlib.contextmanager
 def resolve_dependency(
     type_: t.Type[T],
     resolver_options: ResolverOptions,
     registry: Registry | None = None,
-    provider: t.Callable[..., T] | None = None,
-) -> T:
+    provider: t.Callable[..., T]
+    | t.Callable[..., contextlib.AbstractContextManager[T]]
+    | None = None,
+) -> t.Iterator[T]:
     """Returns a dependency according to configured options.
 
     Args:
@@ -43,8 +47,9 @@ def resolve_dependency(
             the dependency.
         registry (Registry | None, optional): an optional registry containing
             the dependency. Defaults to None.
-        provider (typing.Callable[..., T] | None, optional): an optional
-            function that will return the dependency. Defaults to None.
+        provider: (t.Callable[..., T] | typing.Callable[..., contextlib.AbstractContextManager[T]] | None):
+            an optional context manager function that returns the dependency.
+            Defaults to None.
 
     Raises:
         DependencyResolutionError: if a registry is required but not provided
@@ -55,21 +60,35 @@ def resolve_dependency(
     """
     match resolver_options:
         case ResolverOptions(use_registry=True, initialise_missing=False) if registry is not None:
-            return registry.get(type_)
+            yield registry.get(type_)
         case ResolverOptions(use_registry=True, initialise_missing=False) if registry is None:
             raise DependencyResolutionError("Registry required but not provided.")
         case ResolverOptions(use_registry=True, initialise_missing=True) if registry is not None:
             obj = registry.get(type_, None)
-            return obj if obj is not None else _initialise_dependency(type_, provider)
+            if obj is not None:
+                yield obj
+            else:
+                yield from _initialise_dependency(type_, provider)
         case ResolverOptions(initialise_missing=True) if registry is None:
-            return _initialise_dependency(type_, provider)
-    raise DependencyResolutionError("Unable to resolve dependency.")
+            yield from _initialise_dependency(type_, provider)
+        case _:
+            raise DependencyResolutionError("Unable to resolve dependency.")
 
 
-def _initialise_dependency(type_: t.Type[T], provider: t.Callable[..., T] | None) -> T:
+def _initialise_dependency(
+    type_: t.Type[T],
+    provider: t.Callable[..., contextlib.AbstractContextManager[T]] | t.Callable[..., T] | None,
+) -> t.Iterator[T]:
     if provider is None:
-        return _new_dependency(type_)
-    return provider()
+        yield _new_dependency(type_)
+        return
+    maybe_a_context_manager = provider()
+    match maybe_a_context_manager:
+        case contextlib.AbstractContextManager() as context_manager:
+            with context_manager as obj:
+                yield obj
+        case obj:
+            yield obj
 
 
 def _new_dependency(type_: t.Type[T]) -> T:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -29,7 +29,7 @@ class FakeResolverOptions:
 @pytest.fixture
 def mock_resolver(mocker: pytest_mock.MockerFixture) -> t.Callable:
     mock_resolver = mocker.patch("tidi.resolver.resolve_dependency")
-    mock_resolver.return_value = TEST_DEP
+    mock_resolver.return_value.__enter__.return_value = TEST_DEP
     return mock_resolver
 
 


### PR DESCRIPTION
With this PR, context managers can passed into `tidi.Provider` to then be `__enter__`d during the injection process.

This is made possible by
* making the `tidi.resolver.resolve_dependency` function a context manager itself (so the context can be kept _open_ through the process)
* making `tidi.resolver._initialise_dependency` smart enough to jump into the provider context manager if it is one
* collecting together all the tidi dependencies (from `resolve_dependency`) in a single `contextlib.ExitStack` in the `tidi.decorator.inject` decorator (so that all dependency contexts can be kept _open_ through the process)
